### PR TITLE
Loosen Rails version constraint

### DIFF
--- a/administrate-field-belongs_to_search.gemspec
+++ b/administrate-field-belongs_to_search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'administrate', '>= 0.3', '< 1.0'
   gem.add_dependency 'jbuilder', '~> 2'
-  gem.add_dependency 'rails', '>= 4.2', '< 7.0'
+  gem.add_dependency 'rails', '>= 4.2', '< 7.1'
   gem.add_dependency 'selectize-rails', '~> 0.6'
 
   gem.add_development_dependency 'coveralls', '~> 0'


### PR DESCRIPTION
This will allow Rails 7.0.

This should be safe as the same change has been made upstream. There are no other recent upstream changes that we need to consider at the moment.